### PR TITLE
Update deploy.yaml for mon-fri daily pages refresh

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ on:
   push:
     branches: ["main"]
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: "0 23 * * 1-5"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The cron job should now run at 23:00hrs every weekday. Haven't found anything about cron jobs failing, but potentially an issue might have been the previous frequency so hoping this update will fix any issues.