### PR TITLE
Update Socials (minus changes to Gemfile.lock)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     google-protobuf (3.21.12)
+    google-protobuf (3.21.12-x86_64-darwin)
+    google-protobuf (3.21.12-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -58,12 +60,6 @@ GEM
     sass-embedded (1.58.0)
       google-protobuf (~> 3.21)
       rake (>= 10.0.0)
-    sass-embedded (1.58.0-x64-mingw-ucrt)
-      google-protobuf (~> 3.21)
-    sass-embedded (1.58.0-x86_64-darwin)
-      google-protobuf (~> 3.21)
-    sass-embedded (1.58.0-x86_64-linux-gnu)
-      google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
@@ -71,7 +67,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw-ucrt
   x86_64-darwin-22
   x86_64-linux
 
@@ -81,3 +76,4 @@ DEPENDENCIES
 
 BUNDLED WITH
    2.4.6
+   


### PR DESCRIPTION
Reverting (unintended) changes made to Gemfile.lock in previous commit, which are likely to be the reason the build process is failing.